### PR TITLE
security: add API key authentication for sensitive endpoints

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -9,3 +9,6 @@ ETORO_USER_KEY=your_user_key_here
 
 # Optional: Override the base URL (defaults to https://www.etoro.com/api/public)
 # ETORO_API_BASE_URL=https://www.etoro.com/api/public
+
+# API Authentication (optional - if set, requires x-api-key header for sensitive endpoints)
+API_SECRET_KEY=

--- a/src/app/api/census-stream/route.ts
+++ b/src/app/api/census-stream/route.ts
@@ -4,6 +4,7 @@ import { PeriodType } from '@/lib/models/user';
 import { dataCollectionService } from '@/lib/services/data-collection-service';
 import { analysisService, analysisServiceV2 } from '@/lib/services/analysis-service';
 import { logger } from '@/lib/logger';
+import { validateApiKey } from '@/lib/auth';
 
 // Input validation schema
 const CensusStreamInputSchema = z.object({
@@ -13,6 +14,9 @@ const CensusStreamInputSchema = z.object({
 });
 
 export async function POST(request: NextRequest) {
+  const authError = validateApiKey(request);
+  if (authError) return authError;
+
   const encoder = new TextEncoder();
 
   // Create a streaming response

--- a/src/app/api/extract-instruments/route.ts
+++ b/src/app/api/extract-instruments/route.ts
@@ -1,9 +1,13 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getPopularInvestors, getUserPortfolio } from '@/lib/services/user-service';
 import { getInstrumentDetails } from '@/lib/services/instrument-service';
 import { logger } from '@/lib/logger';
+import { validateApiKey } from '@/lib/auth';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const authError = validateApiKey(request);
+  if (authError) return authError;
+
   try {
     logger.info('Extracting real instrument IDs from portfolios');
     

--- a/src/app/api/optimized-report/route.ts
+++ b/src/app/api/optimized-report/route.ts
@@ -5,6 +5,7 @@ import { dataCollectionService } from '@/lib/services/data-collection-service';
 import { analysisService } from '@/lib/services/analysis-service';
 import { generateReportHTML } from '@/lib/report-generator';
 import { logger } from '@/lib/logger';
+import { validateApiKey } from '@/lib/auth';
 import fs from 'fs/promises';
 import path from 'path';
 import zlib from 'zlib';
@@ -20,6 +21,9 @@ const OptimizedReportInputSchema = z.object({
 });
 
 export async function POST(request: NextRequest) {
+  const authError = validateApiKey(request);
+  if (authError) return authError;
+
   const encoder = new TextEncoder();
 
   // Create a streaming response

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -7,7 +7,7 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const period = (searchParams.get('period') || 'CurrMonth') as PeriodType;
-    const limit = parseInt(searchParams.get('limit') || '50');
+    const limit = Math.min(Math.max(parseInt(searchParams.get('limit') || '50'), 1), 500);
 
     const investors = await getPopularInvestors(period, limit);
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function validateApiKey(request: NextRequest): NextResponse | null {
+  const apiKey = process.env.API_SECRET_KEY;
+
+  // If no API key configured, skip auth (development mode)
+  if (!apiKey) {
+    return null;
+  }
+
+  const providedKey = request.headers.get('x-api-key') ||
+    request.headers.get('authorization')?.replace('Bearer ', '');
+
+  if (providedKey !== apiKey) {
+    return NextResponse.json(
+      { error: 'Unauthorized: Invalid or missing API key' },
+      { status: 401 }
+    );
+  }
+
+  return null; // Auth passed
+}


### PR DESCRIPTION
## Summary
- Adds API key validation for expensive/sensitive endpoints that could be abused
- Protects `/api/optimized-report`, `/api/census-stream`, `/api/extract-instruments`
- Adds bounds validation for `/api/users` limit parameter (1-500)
- Authentication is optional: only enforced when `API_SECRET_KEY` env var is set

## How it works
- Set `API_SECRET_KEY` in your environment
- Include `x-api-key: <your-key>` header or `Authorization: Bearer <your-key>` in requests
- If `API_SECRET_KEY` is not set, all requests are allowed (dev mode)

## Test plan
- [ ] Verify endpoints work without API_SECRET_KEY set (dev mode)
- [ ] Verify endpoints reject requests when API_SECRET_KEY is set but no header provided
- [ ] Verify endpoints accept requests with correct API key header
- [ ] Verify /api/users limit is clamped to 1-500 range

🤖 Generated with [Claude Code](https://claude.com/claude-code)