### PR TITLE
security: fix CVE-2026-1528 undici WebSocket overflow + flatted DoS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7203,9 +7203,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
## Summary
- Updates `undici` 7.22.0 → 7.24.4 to fix **CVE-2026-1528** (High severity — malicious WebSocket 64-bit length overflows parser and crashes the client)
- Updates `flatted` to fix unbounded recursion DoS (GHSA-25h7-pfq9-p65f)
- Resolves Dependabot alert GHSA-f269-vfmq-vjvj
- `npm audit` now shows **0 vulnerabilities**

## Test plan
- [x] `npm audit` passes with 0 vulnerabilities
- [x] `npm run build` succeeds
- [ ] CI passes (Test, Lint & Build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)