### PR TITLE
fix(security): SSRF in /api/personal — env-derived baseUrl

### DIFF
--- a/src/app/api/personal/route.ts
+++ b/src/app/api/personal/route.ts
@@ -27,9 +27,12 @@ export async function GET(request: Request) {
       );
     }
 
-    // Extract base URL for fetch operations on Vercel (same as public endpoint)
-    const url = new URL(request.url);
-    const baseUrl = `${url.protocol}//${url.host}`;
+    // Build base URL from server-controlled env vars (NOT request.url, which
+    // would be user-controlled via Host header → SSRF risk). Mirrors the safe
+    // pattern already used in /api/public/[username]/route.ts. See issue #76.
+    const baseUrl = process.env.VERCEL_URL
+      ? `https://${process.env.VERCEL_URL}`
+      : (process.env.NEXT_PUBLIC_SITE_URL ?? '');
 
     // Fetch all simplified intelligence modules in parallel
     const [


### PR DESCRIPTION
## Summary
- `/api/personal/route.ts` was deriving `baseUrl` from `request.url` (user-controlled `Host` header), creating a server-side fetch sink in `census-data-service.ts:332` that CodeQL flagged as SSRF (issue #76).
- The fix mirrors the safe pattern already used by `/api/public/[username]/route.ts:43-46`: derive `baseUrl` from `VERCEL_URL` / `NEXT_PUBLIC_SITE_URL` env vars (server-controlled), not from request input.
- 3-line diff; no new dependencies; no behavior change for the public endpoint.

## Why fix at the source instead of adding an allowlist
CodeQL flags the *sink* (`fetch(\${baseUrl}\${file})`), but the actual taint enters at the route. Fixing the source eliminates the user-controlled hostname entirely; an allowlist in the service would be defense-in-depth, not the primary fix. We can add it as a follow-up if desired.

## Test plan
- [ ] CI green (CodeQL re-runs and clears the alert)
- [ ] Local: \`/api/personal\` still returns valid data when `VERCEL_URL` or `NEXT_PUBLIC_SITE_URL` is set in the env
- [ ] Confirm SonarCloud no longer flags the sink

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)