### PR TITLE
fix(census): prefer public Vercel alias over VERCEL_URL for self-fetch

### DIFF
--- a/src/app/api/personal/route.ts
+++ b/src/app/api/personal/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { simplifiedIntelligence } from '@/lib/services/simplified-intelligence-service';
 import { logger } from '@/lib/logger';
+import { getInternalBaseUrl } from '@/lib/utils/vercel-base-url';
 
 // Disable all caching for this endpoint
 export const dynamic = 'force-dynamic';
@@ -17,39 +18,35 @@ export async function GET(request: Request) {
         {
           success: false,
           error: 'API_CREDENTIALS_MISSING',
-          message: 'Personal portfolio analysis requires eToro API credentials. Please configure ETORO_API_KEY and ETORO_USER_KEY environment variables in your deployment settings.',
+          message:
+            'Personal portfolio analysis requires eToro API credentials. Please configure ETORO_API_KEY and ETORO_USER_KEY environment variables in your deployment settings.',
           instructions: {
-            vercel: 'Go to Project Settings → Environment Variables and add ETORO_API_KEY and ETORO_USER_KEY',
-            local: 'Create a .env.local file with ETORO_API_KEY and ETORO_USER_KEY values'
-          }
+            vercel:
+              'Go to Project Settings → Environment Variables and add ETORO_API_KEY and ETORO_USER_KEY',
+            local: 'Create a .env.local file with ETORO_API_KEY and ETORO_USER_KEY values',
+          },
         },
-        { status: 503 } // Service Unavailable
+        { status: 503 }, // Service Unavailable
       );
     }
 
     // Build base URL from server-controlled env vars (NOT request.url, which
-    // would be user-controlled via Host header → SSRF risk). Mirrors the safe
-    // pattern already used in /api/public/[username]/route.ts. See issue #76.
-    const baseUrl = process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}`
-      : (process.env.NEXT_PUBLIC_SITE_URL ?? '');
+    // would be user-controlled via Host header → SSRF risk; see issue #76).
+    // Prefer the production/branch alias over VERCEL_URL: the immutable URL
+    // is gated by Vercel Deployment Protection (401 → SSO) which silently
+    // breaks the function's self-fetch in loadCensusData.
+    const baseUrl = getInternalBaseUrl();
 
     // Fetch all simplified intelligence modules in parallel
-    const [
-      portfolio,
-      smartMoney,
-      performance,
-      holdings,
-      risk,
-      eliteGroupComparison
-    ] = await Promise.all([
-      simplifiedIntelligence.getPortfolioSummary(),
-      simplifiedIntelligence.getSmartMoneyAnalysis('all', baseUrl),
-      simplifiedIntelligence.getPerformanceComparison(),
-      simplifiedIntelligence.getTopHoldingsInsights(baseUrl),
-      simplifiedIntelligence.getRiskAssessment(),
-      simplifiedIntelligence.getEliteGroupComparison(baseUrl)
-    ]);
+    const [portfolio, smartMoney, performance, holdings, risk, eliteGroupComparison] =
+      await Promise.all([
+        simplifiedIntelligence.getPortfolioSummary(),
+        simplifiedIntelligence.getSmartMoneyAnalysis('all', baseUrl),
+        simplifiedIntelligence.getPerformanceComparison(),
+        simplifiedIntelligence.getTopHoldingsInsights(baseUrl),
+        simplifiedIntelligence.getRiskAssessment(),
+        simplifiedIntelligence.getEliteGroupComparison(baseUrl),
+      ]);
 
     const response = NextResponse.json({
       success: true,
@@ -59,9 +56,9 @@ export async function GET(request: Request) {
         performance,
         holdings,
         risk,
-        eliteGroupComparison
+        eliteGroupComparison,
       },
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     });
 
     // Add cache control headers to prevent any caching
@@ -71,13 +68,15 @@ export async function GET(request: Request) {
 
     return response;
   } catch (error) {
-    logger.error('Failed to get simplified intelligence', { error: error instanceof Error ? error.message : String(error) });
+    logger.error('Failed to get simplified intelligence', {
+      error: error instanceof Error ? error.message : String(error),
+    });
     return NextResponse.json(
       {
         success: false,
-        error: 'Failed to analyze portfolio'
+        error: 'Failed to analyze portfolio',
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/app/api/public/[username]/route.ts
+++ b/src/app/api/public/[username]/route.ts
@@ -4,15 +4,13 @@ import { censusDataService } from '@/lib/services/census-data-service';
 import { portfolioComparison } from '@/lib/services/portfolio-comparison';
 import { generateUUID } from '@/lib/etoro-api-config';
 import { logger } from '@/lib/logger';
+import { getInternalBaseUrl } from '@/lib/utils/vercel-base-url';
 
 // Disable all caching for this endpoint
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-export async function GET(
-  request: Request,
-  { params }: { params: Promise<{ username: string }> }
-) {
+export async function GET(request: Request, { params }: { params: Promise<{ username: string }> }) {
   try {
     const { username } = await params;
 
@@ -21,9 +19,9 @@ export async function GET(
       return NextResponse.json(
         {
           success: false,
-          error: 'Username is required'
+          error: 'Username is required',
         },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
@@ -33,17 +31,17 @@ export async function GET(
       return NextResponse.json(
         {
           success: false,
-          error: 'Invalid username format. Only letters, numbers, underscore and hyphen allowed.'
+          error: 'Invalid username format. Only letters, numbers, underscore and hyphen allowed.',
         },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    // Trusted base URL for server-side fetch on Vercel.
-    // Derived from environment, NOT from request.url (Host header is user-controlled).
-    const baseUrl = process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}`
-      : (process.env.NEXT_PUBLIC_SITE_URL ?? '');
+    // Trusted base URL for server-side fetch on Vercel. Derived from server-
+    // controlled env vars (Host header is user-controlled → SSRF risk).
+    // Prefers the public alias over the immutable VERCEL_URL, which is gated
+    // by Vercel Deployment Protection and silently 401s on self-fetch.
+    const baseUrl = getInternalBaseUrl();
 
     // Validate username exists
     const isValid = await publicPortfolioService.validateUsername(username);
@@ -51,25 +49,19 @@ export async function GET(
       return NextResponse.json(
         {
           success: false,
-          error: 'Username not found or not a valid eToro investor'
+          error: 'Username not found or not a valid eToro investor',
         },
-        { status: 404 }
+        { status: 404 },
       );
     }
 
     // Fetch portfolio and elite group data in parallel
-    const [
-      portfolio,
-      broadMarket,
-      topCopiers,
-      topPerformers,
-      lowRisk
-    ] = await Promise.all([
+    const [portfolio, broadMarket, topCopiers, topPerformers, lowRisk] = await Promise.all([
       publicPortfolioService.getNormalizedData(username),
       censusDataService.getSmartMoneyFlow('all', baseUrl),
       censusDataService.getSmartMoneyFlow('topCopiers', baseUrl),
       censusDataService.getSmartMoneyFlow('topPerformers', baseUrl),
-      censusDataService.getSmartMoneyFlow('lowRisk', baseUrl)
+      censusDataService.getSmartMoneyFlow('lowRisk', baseUrl),
     ]);
 
     // Use shared comparison service to build elite group comparison
@@ -80,7 +72,7 @@ export async function GET(
       broadMarket,
       topCopiers,
       topPerformers,
-      lowRisk
+      lowRisk,
     );
 
     // Fetch user details (name, photo, PI status)
@@ -92,14 +84,16 @@ export async function GET(
           headers: {
             'X-API-KEY': process.env.ETORO_PERSONAL_API_KEY || process.env.ETORO_API_KEY || '',
             'X-USER-KEY': process.env.ETORO_PERSONAL_USER_KEY || process.env.ETORO_USER_KEY || '',
-            'X-REQUEST-ID': generateUUID()
-          }
-        }
+            'X-REQUEST-ID': generateUUID(),
+          },
+        },
       );
       if (userDetailsResponse.ok) {
         const details = await userDetailsResponse.json();
         if (details.users && Array.isArray(details.users) && details.users.length > 0) {
-          const user = details.users.find((u: Record<string, unknown>) => u.username === username) || details.users[0];
+          const user =
+            details.users.find((u: Record<string, unknown>) => u.username === username) ||
+            details.users[0];
           // Get avatar - the API returns avatars array, pick the 150x150 or first one
           let avatarUrl = null;
           if (user.avatars && Array.isArray(user.avatars) && user.avatars.length > 0) {
@@ -108,16 +102,19 @@ export async function GET(
           }
 
           userDetails = {
-            fullName: user.fullName || `${user.firstName || ''} ${user.lastName || ''}`.trim() || username,
+            fullName:
+              user.fullName || `${user.firstName || ''} ${user.lastName || ''}`.trim() || username,
             avatar: avatarUrl,
             isPopularInvestor: user.isPi || false,
             piLevel: user.piLevel || 0,
-            country: user.country || 0
+            country: user.country || 0,
           };
         }
       }
     } catch (error) {
-      logger.warn('Failed to fetch user details', { error: error instanceof Error ? error.message : String(error) });
+      logger.warn('Failed to fetch user details', {
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
 
     // Build portfolio summary with sorted positions and logos
@@ -136,16 +133,27 @@ export async function GET(
       riskScore: portfolio.riskScore,
       trades: portfolio.trades,
       winRatio: portfolio.winRatio,
-      topPositions: portfolio.positions
-        ?.sort((a: { marketValue: number }, b: { marketValue: number }) => b.marketValue - a.marketValue)
-        ?.slice(0, 10)
-        ?.map((p: { symbol: string; instrumentName?: string; instrumentId: number; marketValue: number }) => ({
-          symbol: p.symbol,
-          instrumentName: p.instrumentName,
-          instrumentId: p.instrumentId,
-          marketValue: p.marketValue,  // This is percentage (0-100) for public portfolios
-          logoUrl: `https://etoro-cdn.etorostatic.com/market-avatars/${p.instrumentId}/150x150.png`
-        })) || []
+      topPositions:
+        portfolio.positions
+          ?.sort(
+            (a: { marketValue: number }, b: { marketValue: number }) =>
+              b.marketValue - a.marketValue,
+          )
+          ?.slice(0, 10)
+          ?.map(
+            (p: {
+              symbol: string;
+              instrumentName?: string;
+              instrumentId: number;
+              marketValue: number;
+            }) => ({
+              symbol: p.symbol,
+              instrumentName: p.instrumentName,
+              instrumentId: p.instrumentId,
+              marketValue: p.marketValue, // This is percentage (0-100) for public portfolios
+              logoUrl: `https://etoro-cdn.etorostatic.com/market-avatars/${p.instrumentId}/150x150.png`,
+            }),
+          ) || [],
     };
 
     // Get performance data from census file (has weekTDReturn, monthTDReturn)
@@ -159,8 +167,8 @@ export async function GET(
         eliteGroupComparison: eliteComparison,
         broadMarketHoldings: broadMarket.topHoldings || [],
         performanceData: performanceHoldings, // Full holdings with Week TD and MTD data
-        timestamp: new Date().toISOString()
-      }
+        timestamp: new Date().toISOString(),
+      },
     });
 
     // Add cache control headers to prevent caching
@@ -170,13 +178,15 @@ export async function GET(
 
     return response;
   } catch (error) {
-    logger.error('Failed to get public portfolio insights', { error: error instanceof Error ? error.message : String(error) });
+    logger.error('Failed to get public portfolio insights', {
+      error: error instanceof Error ? error.message : String(error),
+    });
     return NextResponse.json(
       {
         success: false,
-        error: error instanceof Error ? error.message : 'Failed to analyze portfolio'
+        error: error instanceof Error ? error.message : 'Failed to analyze portfolio',
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/lib/services/census-data-service.ts
+++ b/src/lib/services/census-data-service.ts
@@ -207,12 +207,15 @@ interface CensusData {
     details: CensusInstrumentDetail[];
     priceData: CensusInstrumentPrice[];
   };
-  userDetails?: Record<string, {
-    username: string;
-    avatar?: {
-      url: string;
-    };
-  }>;
+  userDetails?: Record<
+    string,
+    {
+      username: string;
+      avatar?: {
+        url: string;
+      };
+    }
+  >;
   metadata: {
     timestamp: string;
     investorCount: number;
@@ -298,8 +301,8 @@ class CensusDataService {
 
         const dataDir = path.join(process.cwd(), 'public', 'data');
         const dataFiles = [
-          'census-data-latest.json',            // Fixed filename for Vercel deployment
-          'latest-census.json',                 // Symlink fallback (for local dev)
+          'census-data-latest.json', // Fixed filename for Vercel deployment
+          'latest-census.json', // Symlink fallback (for local dev)
         ];
 
         for (const fileName of dataFiles) {
@@ -321,13 +324,13 @@ class CensusDataService {
         // On Vercel serverless, we need absolute URLs, so use baseUrl if provided
         const urlBase = baseUrl || '';
         const dataFiles = [
-          '/data/census-data-latest.json',            // Fixed filename for Vercel deployment
-          '/data/latest-census.json',                 // Symlink fallback (for local dev)
+          '/data/census-data-latest.json', // Fixed filename for Vercel deployment
+          '/data/latest-census.json', // Symlink fallback (for local dev)
         ];
 
         for (const file of dataFiles) {
+          const url = `${urlBase}${file}`;
           try {
-            const url = `${urlBase}${file}`;
             logger.debug('Attempting to load census data', { source: url });
             const response = await fetch(url);
             if (response.ok) {
@@ -337,15 +340,25 @@ class CensusDataService {
               logger.info('Successfully loaded census data', { source: url });
               return this.censusData;
             }
-          } catch (_err) {
-            logger.debug('Census data file not found, trying next', { source: file });
+            logger.warn('Census data fetch returned non-OK response', {
+              source: url,
+              status: response.status,
+              statusText: response.statusText,
+            });
+          } catch (err) {
+            logger.warn('Census data fetch threw', {
+              source: url,
+              error: err instanceof Error ? err.message : String(err),
+            });
           }
         }
       }
 
-      logger.error('Failed to load census data from any source');
+      logger.error('Failed to load census data from any source', { baseUrl });
     } catch (error) {
-      logger.error('Failed to load census data', { error: error instanceof Error ? error.message : String(error) });
+      logger.error('Failed to load census data', {
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
 
     return null;
@@ -362,22 +375,20 @@ class CensusDataService {
     const instrumentDetailsMap = this.getInstrumentDetailsMap();
     const instrumentPriceMap = this.getInstrumentPriceMap();
 
-    return data.analyses[0].topHoldings
-      .slice(0, limit)
-      .map(holding => {
-        const details = instrumentDetailsMap.get(holding.instrumentId);
-        const priceData = instrumentPriceMap.get(holding.instrumentId);
+    return data.analyses[0].topHoldings.slice(0, limit).map((holding) => {
+      const details = instrumentDetailsMap.get(holding.instrumentId);
+      const priceData = instrumentPriceMap.get(holding.instrumentId);
 
-        return {
-          ...holding,
-          name: holding.instrumentName || details?.instrumentDisplayName || holding.symbol,
-          imageUrl: holding.imageUrl || details?.images?.[2]?.uri, // 50x50 image
-          currentPrice: priceData?.currentPrice,
-          dayChange: holding.yesterdayReturn,
-          weekChange: holding.weekTDReturn,
-          monthChange: holding.monthTDReturn
-        };
-      });
+      return {
+        ...holding,
+        name: holding.instrumentName || details?.instrumentDisplayName || holding.symbol,
+        imageUrl: holding.imageUrl || details?.images?.[2]?.uri, // 50x50 image
+        currentPrice: priceData?.currentPrice,
+        dayChange: holding.yesterdayReturn,
+        weekChange: holding.weekTDReturn,
+        monthChange: holding.monthTDReturn,
+      };
+    });
   }
 
   /**
@@ -397,22 +408,24 @@ class CensusDataService {
       .sort((a, b) => b.gain - a.gain)
       .slice(0, limit)
       .map((investor, index) => {
-        const username = investor.username ||
-                        userDetailsMap[Object.keys(userDetailsMap)[index]]?.username ||
-                        `Investor${index + 1}`;
+        const username =
+          investor.username ||
+          userDetailsMap[Object.keys(userDetailsMap)[index]]?.username ||
+          `Investor${index + 1}`;
 
         return {
           ...investor,
           username,
-          portfolioSize: investor.portfolio?.positionsCount || investor.portfolio?.positions?.length || 0,
-          topHoldings: investor.portfolio?.positions?.slice(0, 5).map(p => {
+          portfolioSize:
+            investor.portfolio?.positionsCount || investor.portfolio?.positions?.length || 0,
+          topHoldings: investor.portfolio?.positions?.slice(0, 5).map((p) => {
             const details = instrumentDetailsMap.get(p.instrumentId);
             return {
               symbol: p.symbol || details?.symbolFull || 'N/A',
               allocation: p.percentage,
-              name: details?.instrumentDisplayName || p.symbol || 'Unknown'
+              name: details?.instrumentDisplayName || p.symbol || 'Unknown',
             };
-          })
+          }),
         };
       });
   }
@@ -433,7 +446,7 @@ class CensusDataService {
       averageCashPercent: analysis.averages?.cashPercent || 15,
       averagePositions: analysis.averages?.positions || 20,
       fearGreedIndex: analysis.fearGreedIndex,
-      marketSentiment: this.calculateMarketSentiment(analysis)
+      marketSentiment: this.calculateMarketSentiment(analysis),
     };
   }
 
@@ -449,7 +462,7 @@ class CensusDataService {
     for (const symbol of symbols) {
       let count = 0;
       for (const investor of data.investors) {
-        if (investor.portfolio?.positions?.some(p => p.symbol === symbol)) {
+        if (investor.portfolio?.positions?.some((p) => p.symbol === symbol)) {
           count++;
         }
       }
@@ -463,7 +476,10 @@ class CensusDataService {
    * Get smart money flow (what top investors are buying/selling)
    * Can analyze different investor groups
    */
-  async getSmartMoneyFlow(groupType: 'all' | 'topCopiers' | 'topPerformers' | 'lowRisk' = 'all', baseUrl?: string): Promise<SmartMoneyFlow> {
+  async getSmartMoneyFlow(
+    groupType: 'all' | 'topCopiers' | 'topPerformers' | 'lowRisk' = 'all',
+    baseUrl?: string,
+  ): Promise<SmartMoneyFlow> {
     const data = await this.loadCensusData(baseUrl);
     if (!data) {
       logger.debug('No census data loaded for smart money flow');
@@ -473,10 +489,12 @@ class CensusDataService {
         investorCount: 0,
         topHoldings: [],
         risingStars: [],
-        consensus: []
+        consensus: [],
       };
     }
-    logger.debug('Census data loaded for smart money flow', { investorCount: data.investors?.length });
+    logger.debug('Census data loaded for smart money flow', {
+      investorCount: data.investors?.length,
+    });
 
     // Use memoized map (built when data was loaded)
     const instrumentDetailsMap = this.getInstrumentDetailsMap();
@@ -488,24 +506,20 @@ class CensusDataService {
     switch (groupType) {
       case 'topCopiers':
         // Top 100 by copiers (most trusted)
-        topInvestors = data.investors
-          .sort((a, b) => b.copiers - a.copiers)
-          .slice(0, 100);
+        topInvestors = data.investors.sort((a, b) => b.copiers - a.copiers).slice(0, 100);
         groupDescription = 'Top 100 Most Copied (Social Proof)';
         break;
 
       case 'topPerformers':
         // Top 100 by YTD performance
-        topInvestors = data.investors
-          .sort((a, b) => b.gain - a.gain)
-          .slice(0, 100);
+        topInvestors = data.investors.sort((a, b) => b.gain - a.gain).slice(0, 100);
         groupDescription = 'Top 100 YTD Performers';
         break;
 
       case 'lowRisk':
         // Top 100 by lowest risk score (most conservative)
         topInvestors = data.investors
-          .filter(inv => inv.riskScore !== undefined && inv.riskScore > 0)
+          .filter((inv) => inv.riskScore !== undefined && inv.riskScore > 0)
           .sort((a, b) => (a.riskScore ?? 0) - (b.riskScore ?? 0))
           .slice(0, 100);
         groupDescription = 'Top 100 Conservative (Low Risk)';
@@ -520,7 +534,10 @@ class CensusDataService {
     logger.debug('Smart money flow group selected', { count: topInvestors.length });
 
     // Aggregate their holdings by instrumentId (more reliable than symbol)
-    const holdingsMap = new Map<number, { symbol: string, investors: Set<number>, totalAllocation: number }>();
+    const holdingsMap = new Map<
+      number,
+      { symbol: string; investors: Set<number>; totalAllocation: number }
+    >();
 
     for (let investorIndex = 0; investorIndex < topInvestors.length; investorIndex++) {
       const investor = topInvestors[investorIndex];
@@ -529,19 +546,26 @@ class CensusDataService {
 
       for (const position of investor.portfolio?.positions || []) {
         const currentAllocation = investorPositionsByInstrument.get(position.instrumentId) || 0;
-        const positionAllocation = position.percentage || (100 / Math.max(10, investor.portfolio?.positions?.length || 20));
-        investorPositionsByInstrument.set(position.instrumentId, currentAllocation + positionAllocation);
+        const positionAllocation =
+          position.percentage || 100 / Math.max(10, investor.portfolio?.positions?.length || 20);
+        investorPositionsByInstrument.set(
+          position.instrumentId,
+          currentAllocation + positionAllocation,
+        );
       }
 
       // Now add aggregated positions to the holdings map
-      for (const [instrumentId, totalInvestorAllocation] of investorPositionsByInstrument.entries()) {
+      for (const [
+        instrumentId,
+        totalInvestorAllocation,
+      ] of investorPositionsByInstrument.entries()) {
         const details = instrumentDetailsMap.get(instrumentId);
         const symbol = details?.symbolFull || `ID${instrumentId}`;
 
         const current = holdingsMap.get(instrumentId) || {
           symbol,
           investors: new Set<number>(),
-          totalAllocation: 0
+          totalAllocation: 0,
         };
 
         // Add this investor to the set (ensures unique counting)
@@ -563,7 +587,7 @@ class CensusDataService {
           symbol: data.symbol,
           holdersCount: uniqueHolders,
           averageAllocation: data.totalAllocation / Math.max(1, uniqueHolders),
-          penetration: (uniqueHolders / Math.max(1, topInvestors.length)) * 100
+          penetration: (uniqueHolders / Math.max(1, topInvestors.length)) * 100,
         };
       })
       .sort((a, b) => b.penetration - a.penetration);
@@ -575,8 +599,8 @@ class CensusDataService {
       groupDescription,
       investorCount: topInvestors.length,
       topHoldings: smartHoldings.slice(0, 20),
-      risingStars: smartHoldings.filter(h => h.penetration > 30 && h.penetration < 60),
-      consensus: smartHoldings.filter(h => h.penetration > 60)
+      risingStars: smartHoldings.filter((h) => h.penetration > 30 && h.penetration < 60),
+      consensus: smartHoldings.filter((h) => h.penetration > 60),
     };
   }
 
@@ -631,15 +655,18 @@ class CensusDataService {
       const massRate = massHoldings.get(symbol) || 0;
       const divergence = topRate - massRate;
 
-      if (Math.abs(divergence) > 20) { // Significant divergence
-        const signal: DivergenceOpportunity['signal'] = divergence > 0 ? 'SMART_ACCUMULATING' : 'SMART_DISTRIBUTING';
+      if (Math.abs(divergence) > 20) {
+        // Significant divergence
+        const signal: DivergenceOpportunity['signal'] =
+          divergence > 0 ? 'SMART_ACCUMULATING' : 'SMART_DISTRIBUTING';
         opportunities.push({
           symbol,
           smartMoneyHolding: topRate,
           massHolding: massRate,
           divergence,
           signal,
-          opportunity: divergence > 0 ? 'Consider following smart money' : 'Consider taking profits'
+          opportunity:
+            divergence > 0 ? 'Consider following smart money' : 'Consider taking profits',
         });
       }
     }
@@ -655,7 +682,7 @@ class CensusDataService {
 
     for (const investor of investors) {
       const uniqueSymbols = new Set<string>(
-        investor.portfolio?.positions?.map((p) => p.symbol).filter((s): s is string => !!s) || []
+        investor.portfolio?.positions?.map((p) => p.symbol).filter((s): s is string => !!s) || [],
       );
 
       for (const symbol of uniqueSymbols) {

--- a/src/lib/utils/__tests__/vercel-base-url.test.ts
+++ b/src/lib/utils/__tests__/vercel-base-url.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getInternalBaseUrl } from '../vercel-base-url';
+
+const KEYS = [
+  'VERCEL_PROJECT_PRODUCTION_URL',
+  'VERCEL_BRANCH_URL',
+  'VERCEL_URL',
+  'NEXT_PUBLIC_SITE_URL',
+] as const;
+
+describe('getInternalBaseUrl', () => {
+  const snapshot: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of KEYS) {
+      snapshot[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of KEYS) {
+      if (snapshot[k] === undefined) delete process.env[k];
+      else process.env[k] = snapshot[k];
+    }
+  });
+
+  it('returns empty string when no env vars are set (local dev)', () => {
+    expect(getInternalBaseUrl()).toBe('');
+  });
+
+  it('prefers VERCEL_PROJECT_PRODUCTION_URL over all others', () => {
+    process.env.VERCEL_PROJECT_PRODUCTION_URL = 'etoro-census.vercel.app';
+    process.env.VERCEL_BRANCH_URL = 'etoro-census-git-master-org.vercel.app';
+    process.env.VERCEL_URL = 'etoro-census-abc123-org.vercel.app';
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://example.com';
+    expect(getInternalBaseUrl()).toBe('https://etoro-census.vercel.app');
+  });
+
+  it('falls back to VERCEL_BRANCH_URL on preview deployments (no prod alias)', () => {
+    process.env.VERCEL_BRANCH_URL = 'etoro-census-git-feature-org.vercel.app';
+    process.env.VERCEL_URL = 'etoro-census-xyz789-org.vercel.app';
+    expect(getInternalBaseUrl()).toBe('https://etoro-census-git-feature-org.vercel.app');
+  });
+
+  it('falls back to VERCEL_URL only when no aliases are available', () => {
+    process.env.VERCEL_URL = 'etoro-census-abc123-org.vercel.app';
+    // This URL is auth-protected in practice — captured as last-resort behavior.
+    expect(getInternalBaseUrl()).toBe('https://etoro-census-abc123-org.vercel.app');
+  });
+
+  it('falls back to NEXT_PUBLIC_SITE_URL for non-Vercel deploys', () => {
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://example.com';
+    expect(getInternalBaseUrl()).toBe('https://example.com');
+  });
+
+  it('treats empty-string env vars as unset', () => {
+    process.env.VERCEL_PROJECT_PRODUCTION_URL = '';
+    process.env.VERCEL_URL = 'etoro-census-abc123-org.vercel.app';
+    expect(getInternalBaseUrl()).toBe('https://etoro-census-abc123-org.vercel.app');
+  });
+
+  it('regression: must not fall through to VERCEL_URL when production alias exists', () => {
+    // This is the exact bug — picking VERCEL_URL when a public alias is also set
+    // sends the function's fetch into Vercel Deployment Protection (HTTP 401).
+    process.env.VERCEL_PROJECT_PRODUCTION_URL = 'etoro-census.vercel.app';
+    process.env.VERCEL_URL = 'etoro-census-abc123-org.vercel.app';
+    expect(getInternalBaseUrl()).not.toContain('abc123');
+    expect(getInternalBaseUrl()).toBe('https://etoro-census.vercel.app');
+  });
+});

--- a/src/lib/utils/vercel-base-url.ts
+++ b/src/lib/utils/vercel-base-url.ts
@@ -1,0 +1,38 @@
+/**
+ * Build a publicly-reachable absolute base URL for server-side fetches from
+ * this Next.js deployment back to its own static assets (e.g. /public/data).
+ *
+ * Order of preference matters on Vercel: the *immutable* deployment URL
+ * (VERCEL_URL, e.g. project-abc123-org.vercel.app) is gated by Vercel
+ * Deployment Protection — fetching it returns HTTP 401 with an SSO redirect,
+ * which silently breaks server-side self-fetches inside the same function.
+ * The production alias and per-branch aliases are exempt from protection,
+ * so prefer those.
+ *
+ * Returns '' when no env var resolves (local dev). Callers in that mode
+ * should already be on a non-fetch load path (e.g. filesystem reads).
+ *
+ * Note: all sources are server-controlled env vars — never read the inbound
+ * request's Host header here, that would reopen the SSRF vector closed by #79.
+ */
+export function getInternalBaseUrl(): string {
+  const fromEnv = (key: string): string | undefined => {
+    const v = process.env[key];
+    return v && v.length > 0 ? v : undefined;
+  };
+
+  // 1. Production alias — always public, populated on every prod build.
+  const productionAlias = fromEnv('VERCEL_PROJECT_PRODUCTION_URL');
+  if (productionAlias) return `https://${productionAlias}`;
+
+  // 2. Branch alias — preview deployments, exempt from Deployment Protection.
+  const branchAlias = fromEnv('VERCEL_BRANCH_URL');
+  if (branchAlias) return `https://${branchAlias}`;
+
+  // 3. Immutable deployment URL — last resort; may be auth-gated.
+  const deploymentUrl = fromEnv('VERCEL_URL');
+  if (deploymentUrl) return `https://${deploymentUrl}`;
+
+  // 4. Manual override for non-Vercel deployments.
+  return fromEnv('NEXT_PUBLIC_SITE_URL') ?? '';
+}


### PR DESCRIPTION
## Summary
- `/api/personal` and `/api/public/[username]` were returning empty census data on Vercel (`investorCount: 0`, no `isPopular` flags, no `topMissing`).
- Root cause: the function's self-fetch in `loadCensusData` used `process.env.VERCEL_URL` (immutable deployment URL), which is gated by Vercel Deployment Protection — returns HTTP 401 → SSO redirect. The catch silently swallowed it.
- Fix: new `getInternalBaseUrl()` helper picks the publicly-reachable alias first (`VERCEL_PROJECT_PRODUCTION_URL` → `VERCEL_BRANCH_URL` → `VERCEL_URL` → `NEXT_PUBLIC_SITE_URL`). SSRF safety preserved (still no Host-header use, issue #76 / PR #79). Also upgraded the silent catch to log status + error + resolved baseUrl.

## Test plan
- [x] 7 new unit tests for `getInternalBaseUrl` precedence (333/333 suite green)
- [x] Local `/api/personal` still returns correct shape (investorCount: 1500, 9 isPopular holdings, 5 topMissing per group)
- [ ] After merge & Vercel deploy: re-run `curl https://etoro-census.vercel.app/api/personal` and confirm investorCount > 0 + non-empty topMissing
- [ ] Load `/personal` in browser, confirm Popular ✓ checkmarks and Missing Assets table render

🤖 Generated with [Claude Code](https://claude.com/claude-code)