### PR TITLE
fix(census): default loadCensusData baseUrl to getInternalBaseUrl()

### DIFF
--- a/src/lib/services/census-data-service.ts
+++ b/src/lib/services/census-data-service.ts
@@ -4,6 +4,7 @@
  */
 
 import { logger } from '../logger';
+import { getInternalBaseUrl } from '../utils/vercel-base-url';
 
 // Distribution bucket type (e.g., { "0-10%": 15, "10-20%": 25 })
 type DistributionBuckets = Record<string, number>;
@@ -320,9 +321,12 @@ class CensusDataService {
           }
         }
       } else {
-        // Client-side OR Vercel server-side: Use fetch
-        // On Vercel serverless, we need absolute URLs, so use baseUrl if provided
-        const urlBase = baseUrl || '';
+        // Client-side OR Vercel server-side: Use fetch.
+        // On Vercel serverless we need absolute URLs. Resolve our own base if
+        // the caller didn't pass one (e.g. getTopHoldings, getMarketStats),
+        // otherwise those internal callers race the cache and lose, then fail
+        // with a relative URL fetch.
+        const urlBase = baseUrl || getInternalBaseUrl();
         const dataFiles = [
           '/data/census-data-latest.json', // Fixed filename for Vercel deployment
           '/data/latest-census.json', // Symlink fallback (for local dev)


### PR DESCRIPTION
## Summary
Follow-up to #89. Six internal call sites (getTopHoldings, getTopPerformers, getMarketStats, getInvestorsHolding, getDivergenceOpportunities, calculateHoldingRates) call loadCensusData() without a baseUrl. On Vercel they race the in-memory cache against getSmartMoneyFlow(baseUrl) and, when they lose, fetch a relative URL inside the serverless function — Node fetch throws, the catch swallows, the call returns null.

Visible leftover from #89: popularHoldingsCount stayed 0 on /api/personal even after that fix.

## Change
loadCensusData now falls back to getInternalBaseUrl() when baseUrl is omitted. Explicit-baseUrl callers (the two API route handlers) behave identically.

## Test plan
- [x] All 333 tests still green
- [ ] After merge & deploy: confirm popularHoldingsCount > 0 in /api/personal response on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)